### PR TITLE
feat(#61) : 퍼스널 뮤직 진단 음악 랜덤으로 추천하기 / fix(#62) : 오늘은 그만보기 모달 수정

### DIFF
--- a/src/components/personal/PersonalModal.tsx
+++ b/src/components/personal/PersonalModal.tsx
@@ -13,13 +13,13 @@ const PersonalModal = () => {
 
   useEffect(() => {
     const today = new Date()
-    const visitedDate = HOME_VISITED ? new Date(HOME_VISITED) : null
+    const visitedDate = HOME_VISITED ?? null
 
     const handleMainPop = () => {
-      if (visitedDate && visitedDate > today) {
+      if (visitedDate && visitedDate > today.getTime().toString()) {
         return
       }
-      if (!visitedDate || visitedDate < today) {
+      if (!visitedDate || visitedDate < today.getTime().toString()) {
         setIsModalOpen(true)
       }
     }

--- a/src/shared/personal/personalApi.ts
+++ b/src/shared/personal/personalApi.ts
@@ -67,13 +67,14 @@ export const getRecommendMusic = async (musicPreferenceData: number[]) => {
     .from('musicInfo')
     .select('*')
     .in('genre', musicPreferenceData)
-    .limit(3)
+  const randomMusic = musicInfo?.sort(() => Math.random() - 0.5)
+  const recommendMusicInfo = randomMusic?.slice(0, 3)
+
   if (error) {
     throw new Error(error?.message || 'An unknown error occurred')
   }
-  return musicInfo
+  return recommendMusicInfo
 }
-
 //userInfo 테이블에 userChar 추가
 export const insertUserChar = async ({
   userId,


### PR DESCRIPTION
## 📌 관련 이슈 번호
closed #61
closed #62 

## 요약

- 퍼스널 뮤직 진단 음악 랜덤으로 추천하기
- 오늘은 그만보기 모달 수정

## PR 유형

- [x] 기능 추가
- [x] 버그 수정


## 작업 내용 상세

- MBTI별 퍼스널 음악 진단을 같은 음악보단 다양한 음악으로 추천


src > shared > personal > personalApi.ts
```tsx
  let { data: musicInfo, error } = await supabase
    .from('musicInfo')
    .select('*')
    .in('genre', musicPreferenceData)
// 기존에는 MBTI별 선호하는 장르별 전체 데이터에서 3개만 가져와서 항상 같은 데이터로만 확인됐습니다.
    .limit(3)

//supabase에서 random 필터링을 찾지못해서, 우선 전체 결과값을 받아온다음 랜덤으로 곡을 추천하고 거이에서
3개의 데이터만 추출했습니다.
  const randomMusic = musicInfo?.sort(() => Math.random() - 0.5)
  const recommendMusicInfo = randomMusic?.slice(0, 3)
```
- 오늘은 그만보기 모달 수정

src > components > personal >PeronsalModal.tsx
```tsx

//로컬스토리지에 만료시간을 넣어놓은 값을, 날짜로 제대로 변환하지못해서
  const visitedDate = HOME_VISITED ? new Date(HOME_VISITED) : null
// 없다면 null로 처리하고
 const visitedDate = HOME_VISITED ?? null

//현재 데이터와 비교해서 다시 모달을 띄우는 로직에서도 현재 날짜형식이 아닌 현재날짜를 문자열 형식으로 변환해서
비교로 수정했습니다.
      if (visitedDate && visitedDate > today) {
        return
      }
      if (!visitedDate || visitedDate < today) {
        setIsModalOpen(true)
      }

      if (visitedDate && visitedDate > today.getTime().toString()) { //변경된 로직
        return
      }
      if (!visitedDate || visitedDate < today.getTime().toString()) {
        setIsModalOpen(true)
      }

```

## 리뷰를 요청할 내용

- 현재 재생목록에 담긴 노래는 제외하고 추천하는 로직은, 추후에 시간이 된다면
구현해보겠습니다!
- 오늘의 그만보기 같은 경우는 시간을 테스트 할 때 1분 후로 만료시간 체크 후 제대로 동작하는 지 확인했습니다!

## Trouble Shooting

## Reference (또는 새로 알게 된 내용) 혹은 궁금한 사항들
