### PR TITLE
Fix(#75) : 쿼리키 변경 - 커뮤니티 게시글 수정 새로고침 이슈 생긴점 해결

### DIFF
--- a/src/components/communityDetail/CommunityContents.tsx
+++ b/src/components/communityDetail/CommunityContents.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link'
 import Swal from 'sweetalert2'
 import createDOMPurify from 'dompurify'
 import {
+  updateCommnityInvalidate,
   useCoummunityCreateItem,
   useCoummunityItem,
 } from '@/query/communityDetail/mutation'
@@ -56,11 +57,13 @@ const CommunityContents = () => {
   } = useMusicDataInCommuDetailQuery(uid, currentBoardId)
 
   const {
-    updateCommunityMutation,
+    // updateCommunityMutation,
     deleteCommunityMutation,
     insertMyMutation,
     updateMyMutation,
   } = useCoummunityItem()
+
+  const { updateCommunityMutation } = updateCommnityInvalidate(currentBoardId)
 
   const {
     boardId,

--- a/src/query/communityDetail/mutation.ts
+++ b/src/query/communityDetail/mutation.ts
@@ -19,14 +19,6 @@ export const validateFormBlank = (firstInput: string, secondInput: string) => {
 }
 
 export const useCoummunityItem = () => {
-  const updateCommunityMutation = useMutation({
-    mutationFn: updateCommnityBoard,
-    onSuccess: () =>
-      queryClient.invalidateQueries({
-        queryKey: [GET_COMMUNITY_DETAIL_QUERY_KEYS.COMMUNITY_DETAIL],
-      }),
-  })
-
   const deleteCommunityMutation = useMutation({
     mutationFn: deleteCommunityBoard,
     onSuccess: () =>
@@ -61,7 +53,7 @@ export const useCoummunityItem = () => {
   })
 
   return {
-    updateCommunityMutation,
+    // updateCommunityMutation,
     deleteCommunityMutation,
     addCommunityMutation,
     insertMyMutation,
@@ -88,4 +80,19 @@ export const useCoummunityCreateItem = () => {
     },
   })
   return { updateMutation, insertMutation }
+}
+
+export const updateCommnityInvalidate = (currentBoardId: string) => {
+  const updateCommunityMutation = useMutation({
+    mutationFn: updateCommnityBoard,
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [
+          `${GET_COMMUNITY_DETAIL_QUERY_KEYS.COMMUNITY_DETAIL}-${currentBoardId}`,
+        ],
+      }),
+  })
+  return {
+    updateCommunityMutation,
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈 번호

closed #75 

## 요약

쿼리키 변경 - 커뮤니티 게시글 수정 새로고침 이슈 생긴점 해결

## PR 유형

- [x] 기능 추가
- [x] 버그 수정
- [x] 파일 혹은 폴더 수정/삭제

## 작업 내용 상세

- 쿼리키 변경 - 커뮤니티 게시글 수정 새로고침 이슈 생긴점 해결
```tsx
export const updateCommnityInvalidate = (currentBoardId: string) => {
  const updateCommunityMutation = useMutation({
    mutationFn: updateCommnityBoard,
    onSuccess: () =>
      queryClient.invalidateQueries({
        queryKey: [
          `${GET_COMMUNITY_DETAIL_QUERY_KEYS.COMMUNITY_DETAIL}-${currentBoardId}`,
        ],
      }),
  })
  return {
    updateCommunityMutation,
  }
}


```


## 리뷰를 요청할 내용

팀원들의 리뷰가 필요한 내용이 있다면 명시해주세요.

## Trouble Shooting

## Reference (또는 새로 알게 된 내용) 혹은 궁금한 사항들
